### PR TITLE
fix: Add bottom padding to dashboard area

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -424,10 +424,9 @@ body {
     .main-chart-container {
         order: 2;
         min-height: 450px;
-        margin-bottom: 5rem;
     }
     .dashboard-area {
-        padding: 1.5rem;
+        padding: 1.5rem 1.5rem 5rem;
     }
     .kpi-value {
         font-size: 1.8rem;


### PR DESCRIPTION
Previously, the main chart container touched the bottom of the screen on certain resolutions. This was because the `margin-bottom` property on the chart container was not effective within the flexbox and grid layout.

This change removes the ineffective margin and instead applies padding to the bottom of the parent `.dashboard-area` container. This ensures there is always adequate spacing below the chart, resolving the visual bug.