### PR TITLE
Ensure KPI cards precede chart on large screens

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -112,6 +112,9 @@
             </header>
             
             <div class="dashboard-grid">
+                <div class="kpi-container-wrapper">
+                    <section id="kpi-container" class="kpi-container"></section>
+                </div>
                 <div class="main-chart-container">
                     <div id="chart-wrapper">
                         <canvas id="salesChart"></canvas>
@@ -120,9 +123,6 @@
                             <p>Awaiting data to generate insights</p>
                         </div>
                     </div>
-                </div>
-                <div class="kpi-container-wrapper">
-                    <section id="kpi-container" class="kpi-container"></section>
                 </div>
             </div>
 

--- a/public/style.css
+++ b/public/style.css
@@ -257,17 +257,25 @@ body {
 .dashboard-grid {
     display: grid;
     grid-template-columns: 1fr;
-    grid-template-rows: auto 1fr;
+    grid-template-rows: auto minmax(0, 1fr);
+    grid-template-areas:
+        "kpis"
+        "chart";
     gap: 1.5rem;
     flex-grow: 1;
     min-height: 0;
 }
 
 .main-chart-container {
+    grid-area: chart;
     display: flex;
     flex-direction: column;
     min-height: 0;
     overflow: hidden;
+}
+
+.kpi-container-wrapper {
+    grid-area: kpis;
 }
 
 .kpi-container {
@@ -416,13 +424,9 @@ body {
 /* --- RESPONSIVE ADJUSTMENTS --- */
 @media (max-width: 1600px) {
     .dashboard-grid {
-        grid-template-rows: auto 1fr;
-    }
-    .kpi-container-wrapper {
-        order: 1; 
+        grid-template-rows: auto minmax(0, 1fr);
     }
     .main-chart-container {
-        order: 2;
         min-height: 450px;
         margin-bottom: 5rem;
     }


### PR DESCRIPTION
## Summary
- ensure the KPI cards render ahead of the chart in the dashboard markup so they stay in the first row on large displays
- allow the main chart container to occupy the remaining height beneath the KPIs on large displays
- keep existing responsive tweaks for smaller screens intact

## Testing
- Not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68f7f6356f5083299c9b9b73ed22f199