### PR TITLE
Ensure chart resizes after fullscreen toggle

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -112,6 +112,9 @@
             </header>
             
             <div class="dashboard-grid">
+                <div class="kpi-container-wrapper">
+                    <section id="kpi-container" class="kpi-container"></section>
+                </div>
                 <div class="main-chart-container">
                     <div id="chart-wrapper">
                         <canvas id="salesChart"></canvas>
@@ -120,9 +123,6 @@
                             <p>Awaiting data to generate insights</p>
                         </div>
                     </div>
-                </div>
-                <div class="kpi-container-wrapper">
-                    <section id="kpi-container" class="kpi-container"></section>
                 </div>
             </div>
 

--- a/public/script.js
+++ b/public/script.js
@@ -43,6 +43,9 @@ document.addEventListener('DOMContentLoaded', () => {
     const generatePanel = document.getElementById('generate-panel');
     const chartPlaceholder = document.getElementById('chart-placeholder');
     const fullscreenBtn = document.getElementById('fullscreen-btn');
+    const mainChartContainer = document.querySelector('.main-chart-container');
+    const chartWrapper = document.getElementById('chart-wrapper');
+    const fullscreenIcon = fullscreenBtn?.querySelector('i');
     const fileInfoContainer = document.getElementById('file-info-container');
     const fileNameEl = document.getElementById('file-name');
     const deleteFileBtn = document.getElementById('delete-file-btn');
@@ -64,6 +67,42 @@ document.addEventListener('DOMContentLoaded', () => {
     const cancelClearBtn = document.getElementById('cancel-clear-btn');
     const selectedDatesDisplay = document.getElementById('selected-dates-display');
     const selectedDatesList = document.getElementById('selected-dates-list');
+
+    let chartResizeObserver = null;
+
+    const refreshChartLayout = () => {
+        if (!salesChart) return;
+        requestAnimationFrame(() => {
+            if (!salesChart) return;
+            salesChart.resize();
+            salesChart.update('none');
+        });
+    };
+
+    const initChartResizeObserver = () => {
+        if (!window.ResizeObserver || chartResizeObserver || !mainChartContainer) return;
+        chartResizeObserver = new ResizeObserver(() => refreshChartLayout());
+        chartResizeObserver.observe(mainChartContainer);
+        if (chartWrapper && chartWrapper !== mainChartContainer) {
+            chartResizeObserver.observe(chartWrapper);
+        }
+    };
+
+    const handleFullscreenChange = () => {
+        const isChartFullscreen = document.fullscreenElement === mainChartContainer ||
+            document.webkitFullscreenElement === mainChartContainer;
+
+        if (fullscreenIcon) {
+            fullscreenIcon.classList.toggle('fa-expand', !isChartFullscreen);
+            fullscreenIcon.classList.toggle('fa-compress', isChartFullscreen);
+        }
+
+        refreshChartLayout();
+
+        if (!isChartFullscreen) {
+            setTimeout(() => window.dispatchEvent(new Event('resize')), 100);
+        }
+    };
 
 
     // --- AUTHENTICATION LISTENER --- //
@@ -338,7 +377,22 @@ document.addEventListener('DOMContentLoaded', () => {
         deleteFileBtn.addEventListener('click', handleDeleteFile);
         updateChartBtn.addEventListener('click', handleUpdateChart);
         comparisonModesContainer.addEventListener('click', handleModeSelection);
-        fullscreenBtn.addEventListener('click', () => document.querySelector('.main-chart-container').requestFullscreen());
+        fullscreenBtn.addEventListener('click', () => {
+            if (!mainChartContainer) return;
+            if (document.fullscreenElement === mainChartContainer || document.webkitFullscreenElement === mainChartContainer) {
+                if (document.exitFullscreen) {
+                    document.exitFullscreen();
+                } else if (document.webkitExitFullscreen) {
+                    document.webkitExitFullscreen();
+                }
+            } else {
+                if (mainChartContainer.requestFullscreen) {
+                    mainChartContainer.requestFullscreen();
+                } else if (mainChartContainer.webkitRequestFullscreen) {
+                    mainChartContainer.webkitRequestFullscreen();
+                }
+            }
+        });
         chartTypeSwitcher.addEventListener('click', handleChartTypeSwitch);
         panelToggleBtn.addEventListener('click', toggleControlPanel);
         todaysSalesInput.addEventListener('input', handlePastedDataUpdate);
@@ -379,9 +433,10 @@ document.addEventListener('DOMContentLoaded', () => {
         });
 
         setupDragAndDrop();
-        document.addEventListener('fullscreenchange', () => {
-            if (!document.fullscreenElement) setTimeout(() => window.dispatchEvent(new Event('resize')), 50);
-        });
+        document.addEventListener('fullscreenchange', handleFullscreenChange);
+        document.addEventListener('webkitfullscreenchange', handleFullscreenChange);
+
+        initChartResizeObserver();
     };
 
     const togglePeakHourHighlight = () => {
@@ -1035,6 +1090,7 @@ document.addEventListener('DOMContentLoaded', () => {
             };
         }
         salesChart = new Chart(ctx, chartConfig);
+        refreshChartLayout();
     };
 
     const generateInsights = (todayData, comparisonData) => {

--- a/public/style.css
+++ b/public/style.css
@@ -257,17 +257,25 @@ body {
 .dashboard-grid {
     display: grid;
     grid-template-columns: 1fr;
-    grid-template-rows: auto 1fr;
+    grid-template-rows: auto minmax(0, 1fr);
+    grid-template-areas:
+        "kpis"
+        "chart";
     gap: 1.5rem;
     flex-grow: 1;
     min-height: 0;
 }
 
 .main-chart-container {
+    grid-area: chart;
     display: flex;
     flex-direction: column;
     min-height: 0;
     overflow: hidden;
+}
+
+.kpi-container-wrapper {
+    grid-area: kpis;
 }
 
 .kpi-container {
@@ -416,13 +424,9 @@ body {
 /* --- RESPONSIVE ADJUSTMENTS --- */
 @media (max-width: 1600px) {
     .dashboard-grid {
-        grid-template-rows: auto 1fr;
-    }
-    .kpi-container-wrapper {
-        order: 1; 
+        grid-template-rows: auto minmax(0, 1fr);
     }
     .main-chart-container {
-        order: 2;
         min-height: 450px;
         margin-bottom: 5rem;
     }


### PR DESCRIPTION
## Summary
- ensure the KPI cards render ahead of the chart in the dashboard markup so they stay in the first row on large displays
- allow the main chart container to occupy the remaining height beneath the KPIs on large displays
- keep existing responsive tweaks for smaller screens intact
- force the chart to remeasure itself when entering or exiting fullscreen so it resizes correctly

## Testing
- Not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68f7f6356f5083299c9b9b73ed22f199